### PR TITLE
Remove usage of mdDoc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,8 +92,8 @@
           meta.maintainers = [ lib.maintainers.ners ];
 
           options.nix.monitored = with lib; {
-            enable = mkEnableOption (mdDoc "nix-monitored, an improved output formatter for Nix");
-            notify = mkEnableOption (mdDoc "notifications using libnotify") // {
+            enable = mkEnableOption "nix-monitored, an improved output formatter for Nix";
+            notify = mkEnableOption "notifications using libnotify" // {
               default = pkgs.stdenv.isLinux;
               defaultText = "pkgs.stdenv.isLinux";
             };


### PR DESCRIPTION
This function was deprecated then removed recently, which means folks using a recent nixpkgs with nix-monitored will observe breakages.

I _think_ the fix here is correct (just dropping mdDoc), but would appreciate a double check.