### PR TITLE
Add platforms

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,9 @@
           # and all the propagated outputs have already been fixed up for the Nix derivation.
           dontFixup = true;
 
-          meta.mainProgram = "nix";
+          meta = {
+            inherit (nix.meta) mainProgram platforms;
+          };
         };
       overlay = final: prev: {
         nix-monitored = final.callPackage nix-monitored { };


### PR DESCRIPTION
Fixes #9 

Made it that `platforms` is inherited from regular nix package.
Worked in my configuration